### PR TITLE
Fix send/receive logic to depend only on Tor network

### DIFF
--- a/app/src/main/java/com/zsolutions/peerlinkyz/PeerLinkyzApplication.kt
+++ b/app/src/main/java/com/zsolutions/peerlinkyz/PeerLinkyzApplication.kt
@@ -50,13 +50,7 @@ class PeerLinkyzApplication : MultiDexApplication() {
                             android.util.Log.d("PeerLinkyzApplication", "HttpClient initialized with Tor proxy")
                         } catch (e: Exception) {
                             android.util.Log.e("PeerLinkyzApplication", "Failed to initialize HttpClient with Tor proxy: ${e.message}")
-                            // Fallback to direct connection if Tor is not available
-                            httpClient = HttpClient(OkHttp) {
-                                install(WebSockets) {
-                                    maxFrameSize = Long.MAX_VALUE
-                                }
-                            }
-                            android.util.Log.d("PeerLinkyzApplication", "HttpClient initialized without Tor proxy as fallback")
+                            android.util.Log.e("PeerLinkyzApplication", "Tor is required for all connections. HttpClient will remain null until Tor is ready.")
                         }
                     }
                 }

--- a/app/src/main/java/com/zsolutions/peerlinkyz/p2p/P2pClient.kt
+++ b/app/src/main/java/com/zsolutions/peerlinkyz/p2p/P2pClient.kt
@@ -12,13 +12,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 
-class P2pClient(private val scope: CoroutineScope) {
-
-    private val client = HttpClient { 
-        install(WebSockets) {
-            maxFrameSize = Long.MAX_VALUE
-        }
-    }
+class P2pClient(
+    private val scope: CoroutineScope,
+    private val httpClient: HttpClient
+) {
     private val messageChannel = Channel<String>(Channel.UNLIMITED)
     private var session: WebSocketSession? = null
     private var connectionJob: Job? = null
@@ -40,7 +37,7 @@ class P2pClient(private val scope: CoroutineScope) {
                 isConnecting = true
                 try {
                     Log.d("P2pClient", "Attempting to connect to $address (attempt ${retryCount + 1})")
-                    client.webSocket(address) {
+                    httpClient.webSocket(address) {
                         session = this
                         isConnecting = false
                         retryCount = 0 // Reset retry count on successful connection


### PR DESCRIPTION
- Updated P2pClient to accept Tor-enabled HttpClient instead of creating its own
- Removed fallback mechanisms in PeerLinkyzApplication that bypass Tor
- Updated ChatActivity to use P2pClient for all WebSocket connections
- Ensured all networking routes through Tor SOCKS proxy only
- Consolidated networking architecture for consistent Tor usage