### PR TITLE
Make p2pClient public with robust connection management

### DIFF
--- a/app/src/main/java/com/zsolutions/peerlinkyz/ChatActivity.kt
+++ b/app/src/main/java/com/zsolutions/peerlinkyz/ChatActivity.kt
@@ -52,7 +52,7 @@ class ChatActivity : AppCompatActivity() {
     private var outboxProcessingJob: Job? = null
 
     private lateinit var p2pManager: P2pManager
-    private val p2pClient: P2pClient? get() = p2pManager.getP2pClient()
+    private val p2pClient: P2pClient? get() = p2pManager.p2pClient
     private lateinit var cryptoManager: CryptoManager
     private lateinit var outboxRepository: com.zsolutions.peerlinkyz.db.OutboxRepository
 


### PR DESCRIPTION
# Make p2pClient public with robust connection management

## Summary

This PR implements the requested changes to make the `p2pClient` variable public and adds robust connection lifetime management to prevent message loss during connection drops. The key improvements include:

- **Public Access**: Made `p2pClient` variable public with private setter for direct access while maintaining encapsulation
- **Automatic Connection Monitoring**: Added continuous monitoring that checks connection status every 5 seconds
- **Automatic Re-instantiation**: When connection drops and Tor is ready, creates new P2pClient instances automatically
- **Message Retry Logic**: Enhanced `sendMessage()` with 3-attempt retry mechanism to handle temporary connection issues
- **Improved Lifecycle Management**: Better cleanup in `stop()` method and proper resource management

## Review & Testing Checklist for Human

**High Priority** (please verify these thoroughly):
- [ ] **Connection Recovery**: Test real-world scenarios where network connection drops - verify that new P2pClient instances are created and messaging resumes automatically
- [ ] **Message Reliability**: Send messages during connection instability to ensure no messages are lost due to the retry logic and reconnection mechanism  
- [ ] **Resource Cleanup**: Monitor memory usage during extended use to verify old P2pClient/HttpClient instances are properly disposed and don't leak resources
- [ ] **Threading Safety**: Test concurrent scenarios (rapid connect/disconnect, sending messages during reconnection) to check for race conditions

**Medium Priority**:
- [ ] **Performance Impact**: Verify the 5-second connection monitoring doesn't impact app responsiveness or battery life

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    ChatActivity["ChatActivity.kt<br/>Direct p2pClient access"]:::minor-edit
    P2pManager["P2pManager.kt<br/>Public p2pClient + monitoring"]:::major-edit
    P2pClient["P2pClient.kt<br/>Retry logic in sendMessage"]:::minor-edit
    TorService["WorkingTorService.kt<br/>Tor network management"]:::context
    
    ChatActivity -->|"accesses"| P2pManager
    P2pManager -->|"creates/manages"| P2pClient
    P2pManager -->|"observes status"| TorService
    P2pClient -->|"uses proxy from"| TorService
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB    
    classDef context fill:#FFFFFF
```

### Notes

**⚠️ Testing Limitation**: These changes could only be verified through compilation/lint checks since the P2P functionality requires Tor network setup and multiple devices for end-to-end testing. The connection monitoring and retry logic need real-world validation.

**Key Implementation Details**:
- Connection monitoring runs in a coroutine with 5-second intervals
- P2pClient instances are recreated (not just reconnected) when connection drops to ensure clean state
- Existing outbox pattern in ChatActivity provides additional message reliability layer
- Removed redundant `getP2pClient()` method to avoid Kotlin property/method declaration clash

---
**Link to Devin run**: https://app.devin.ai/sessions/9ccd20cd141045ac8ac45319232a81a2  
**Requested by**: Tamer (@tmg2000)